### PR TITLE
Update to sticker 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,28 +24,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -72,11 +55,6 @@ dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "build_const"
@@ -108,39 +86,6 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "clap"
-version = "2.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "clicolors-control"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "conllx"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,23 +93,6 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "console"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -266,11 +194,6 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "encode_unicode"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,18 +289,6 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "indicatif"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "indoc"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,14 +378,6 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -600,14 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,37 +525,12 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ordermap"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "paste"
@@ -913,14 +783,6 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,11 +799,6 @@ dependencies = [
 [[package]]
 name = "scopeguard"
 version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "scopeguard"
-version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -996,11 +853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "socket2"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,13 +869,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "stdinout"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "sticker"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1036,9 +883,11 @@ dependencies = [
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "sticker-tf-proto 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sticker-tf-proto 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tensorflow 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1047,42 +896,16 @@ version = "0.1.0"
 dependencies = [
  "conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pyo3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sticker-utils 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sticker 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sticker-tf-proto"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "sticker-utils"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "finalfusion 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sticker 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tensorflow 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
@@ -1153,35 +976,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "termios"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1191,11 +990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
@@ -1215,11 +1009,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vcpkg"
 version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "vec_map"
-version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1273,23 +1062,16 @@ dependencies = [
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum aligned_alloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9dcebfb002ccde769c15bc841d0d5548a90e80fcd2ffed5131339e8074746f0a"
-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
-"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
 "checksum backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "18b50f5258d1a9ad8396d2d345827875de4261b158124d4c819d9b351454fae5"
 "checksum backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "5b3a000b9c543553af61bc01cbfc403b04b5caa9e421033866f2e98061eb3e61"
-"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
-"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
-"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c38ec5642ce1b214866b917b82093a0fe9c75503dc005763737873aa4cfa4a94"
-"checksum console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca57c2c14b8a2bf3105bc9d15574aad80babf6a9c44b1058034cdf8bd169628"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
@@ -1300,7 +1082,6 @@ dependencies = [
 "checksum curl 0.4.22 (registry+https://github.com/rust-lang/crates.io-index)" = "f8ed9a22aa8c4e49ac0c896279ef532a43a7df2f54fcd19fa36960de029f965f"
 "checksum curl-sys 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "5e90ae10f635645cba9cad1023535f54915a95c58c44751c6ed70dbaeb17a408"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
-"checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum filetime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "450537dc346f0c4d738dda31e790da1da5d4bd12145aad4da0d03d713cb3794f"
@@ -1311,7 +1092,6 @@ dependencies = [
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum ghost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5297b71943dc9fea26a3241b178c140ee215798b7f79f7773fd61683e25bca74"
 "checksum half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9353c2a89d550b58fa0061d8ed8d002a7d8cdf2494eb0e432859bd3a9e543836"
-"checksum indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c60da1c9abea75996b70a931bba6c750730399005b61ccd853cee50ef3d0d0c"
 "checksum indoc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9553c1e16c114b8b77ebeb329e5f2876eed62a8d51178c8bc6bff0d65f98f8"
 "checksum indoc-impl 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b714fc08d0961716390977cdff1536234415ac37b509e34e5a983def8340fb75"
 "checksum inventory 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f4cece20baea71d9f3435e7bbe9adf4765f091c5fe404975f844006964a71299"
@@ -1323,7 +1103,6 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
-"checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3"
 "checksum matrixmultiply 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "dcad67dcec2d58ff56f6292582377e6921afdf3bfbd533e26fb8900ae575e002"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
@@ -1339,13 +1118,10 @@ dependencies = [
 "checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
-"checksum number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbf9993e59c894e3c08aa1c2712914e9e6bf1fcbfc6bef283e2183df345a4fee"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-"checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-"checksum parking_lot_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a7bbaa05312363e0480e1efee133fff1a09ef4a6406b65e226b9a793c223a32"
 "checksum paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "423a519e1c6e828f1e73b720f9d9ed2fa643dce8a7737fb43235ce0b41eeaa49"
 "checksum paste-impl 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4214c9e912ef61bf42b81ba9a47e8aad1b2ffaf739ab162bf96d1e011f54e6c5"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
@@ -1374,42 +1150,31 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
-"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "318690c4f04ae6553665f3846c0614c9995bb1ea51a2f1c5c4b4ed338c248b49"
 "checksum serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)" = "5ea8eb91549d859275aef70c58bb30bd62ce50e5eb1a52d32b1b6886e02f7bce"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
-"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4e626972d3593207547f14bf5fc9efa4d0e7283deb73fef1dff313dae9ab8878"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-"checksum stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29f1026ef7b2ded56453d708809e15f148b7f5b6a51e1ee0237964881ab85680"
-"checksum sticker 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71fd9c3060c8e5717169ff48d6e36a526a3d4e3763727d172f06d403c6d53a2b"
-"checksum sticker-tf-proto 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64e002d1798ea5285f75456aa0dc731d4b331dd2b53a9a873a781540483b1081"
-"checksum sticker-utils 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7c294e50af16329a58618d4c43840fc591bfaf5997a6ebe5d32d94c21e13420"
-"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum sticker 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d52ff353ae5fa9b39de4b23847785b2d56cf6952b9f9738afd57ef1cc50cb613"
+"checksum sticker-tf-proto 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f1cec68d3b491f2c5c9fc4cd42251e31261b17ac8d712746062d0cbf2cbc82c3"
 "checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 "checksum tensorflow 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e798f185e00736e185ee1f4a15e0cc788ff01222913a4060d62ffeafde442d7e"
 "checksum tensorflow-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f45e5e974e61ac7efaeb52f63d5a596cce8f2197ddde9788fcc35aca40f2ccc5"
-"checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
-"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
-"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unindent 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c7d0d32a92c9ed197278e09140c32dec854ad5826f0e0e18c1d2a1690f15c8d5"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
-"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ features = ["extension-module"]
 
 [dependencies]
 conllx = "0.12"
-sticker-utils = "0.9"
+sticker = "0.10"

--- a/nix/Cargo.nix
+++ b/nix/Cargo.nix
@@ -112,27 +112,6 @@ rec {
         features = {
         };
       };
-    "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "ansi_term";
-        version = "0.11.0";
-        edition = "2015";
-        sha256 = "08fk0p2xvkqpmz3zlrwnf6l8sj2vngw464rvzspzp31sbgxbwm4v";
-        authors = [
-          "ogham@bsago.me"
-          "Ryan Scheel (Havvy) <ryan.havvy@gmail.com>"
-          "Josh Triplett <josh@joshtriplett.org>"
-        ];
-        dependencies = {
-          "winapi" = {
-            packageId = "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = (target."os" == "windows");
-            features = [ "errhandlingapi" "consoleapi" "processenv" ];
-          };
-        };
-        features = {
-        };
-      };
     "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "arrayvec";
@@ -151,30 +130,6 @@ rec {
         features = {
           "default" = [ "std" ];
           "serde-1" = [ "serde" ];
-        };
-      };
-    "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "atty";
-        version = "0.2.13";
-        edition = "2015";
-        sha256 = "0a1ii8h9fvvrq05bz7j135zjjz1sjz6n2invn2ngxqri0jxgmip2";
-        authors = [
-          "softprops <d.tangren@gmail.com>"
-        ];
-        dependencies = {
-          "libc" = {
-            packageId = "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)";
-            usesDefaultFeatures = false;
-            target = target."unix";
-          };
-          "winapi" = {
-            packageId = "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = target."windows";
-            features = [ "consoleapi" "processenv" "minwinbase" "minwindef" "winbase" ];
-          };
-        };
-        features = {
         };
       };
     "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -242,19 +197,6 @@ rec {
         features = {
           "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
         };
-      };
-    "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "bitflags";
-        version = "1.1.0";
-        edition = "2015";
-        sha256 = "1iwa4jrqcf4lnbwl562a3lx3r0jkh1j88b219bsqvbm4sni67dyv";
-        authors = [
-          "The Rust Project Developers"
-        ];
-        features = {
-        };
-        resolvedDefaultFeatures = [ "default" ];
       };
     "build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
@@ -338,99 +280,6 @@ rec {
         features = {
         };
       };
-    "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "clap";
-        version = "2.33.0";
-        edition = "2015";
-        sha256 = "054n9ngh6pkknpmd4acgdsp40iw6f5jzq8a4h2b76gnbvk6p5xjh";
-        authors = [
-          "Kevin K. <kbknapp@gmail.com>"
-        ];
-        dependencies = {
-          "ansi_term" = {
-            packageId = "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            optional = true;
-            target = (!target."windows");
-          };
-          "atty" = {
-            packageId = "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)";
-            optional = true;
-          };
-          "bitflags" = "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "strsim" = {
-            packageId = "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            optional = true;
-          };
-          "textwrap" = "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "unicode-width" = "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)";
-          "vec_map" = {
-            packageId = "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)";
-            optional = true;
-          };
-        };
-        features = {
-          "color" = [ "ansi_term" "atty" ];
-          "default" = [ "suggestions" "color" "vec_map" ];
-          "doc" = [ "yaml" ];
-          "lints" = [ "clippy" ];
-          "suggestions" = [ "strsim" ];
-          "wrap_help" = [ "term_size" "textwrap/term_size" ];
-          "yaml" = [ "yaml-rust" ];
-        };
-        resolvedDefaultFeatures = [ "ansi_term" "atty" "color" "default" "strsim" "suggestions" "vec_map" ];
-      };
-    "clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "clicolors-control";
-        version = "1.0.0";
-        edition = "2015";
-        sha256 = "02vi8lmf17w4mqjm0rh46ij750bxam2w3a9yxak6i26xhryh77zl";
-        authors = [
-          "Armin Ronacher <armin.ronacher@active-4.com>"
-        ];
-        dependencies = {
-          "atty" = {
-            packageId = "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = target."windows";
-          };
-          "lazy_static" = "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "libc" = {
-            packageId = "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = target."unix";
-          };
-          "winapi" = {
-            packageId = "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = target."windows";
-            features = [ "winbase" "handleapi" "consoleapi" "processenv" ];
-          };
-        };
-        features = {
-          "default" = [ "terminal_autoconfig" ];
-        };
-        resolvedDefaultFeatures = [ "default" "terminal_autoconfig" ];
-      };
-    "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "cloudabi";
-        version = "0.0.3";
-        edition = "2015";
-        sha256 = "1z9lby5sr6vslfd14d6igk03s7awf91mxpsfmsp3prxbxlk0x7h5";
-        libPath = "cloudabi.rs";
-        authors = [
-          "Nuxi (https://nuxi.nl/) and contributors"
-        ];
-        dependencies = {
-          "bitflags" = {
-            packageId = "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            optional = true;
-          };
-        };
-        features = {
-          "default" = [ "bitflags" ];
-        };
-        resolvedDefaultFeatures = [ "bitflags" "default" ];
-      };
     "conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "conllx";
@@ -444,40 +293,6 @@ rec {
           "failure" = "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)";
           "itertools" = "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)";
           "petgraph" = "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-        };
-      };
-    "console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "console";
-        version = "0.7.7";
-        edition = "2015";
-        sha256 = "0sh4gx811yai8r0n02pm6kyds501znc5762z0b50hk961j8psfij";
-        authors = [
-          "Armin Ronacher <armin.ronacher@active-4.com>"
-        ];
-        dependencies = {
-          "atty" = "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)";
-          "clicolors-control" = "clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "encode_unicode" = {
-            packageId = "encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = target."windows";
-          };
-          "lazy_static" = "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "libc" = "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)";
-          "parking_lot" = "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "regex" = "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)";
-          "termios" = {
-            packageId = "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = target."unix";
-          };
-          "unicode-width" = "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)";
-          "winapi" = {
-            packageId = "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = target."windows";
-            features = [ "winbase" "winuser" "consoleapi" "processenv" "wincon" ];
-          };
         };
         features = {
         };
@@ -730,20 +545,6 @@ rec {
           "default" = [ "use_std" ];
         };
       };
-    "encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "encode_unicode";
-        version = "0.3.5";
-        edition = "2015";
-        sha256 = "01qvydmk3mbq19carzbmzbds5ck0hskb60sm7ab474vzm5ws0i02";
-        authors = [
-          "Torbjørn Birch Moltu <t.b.moltu@lyse.net>"
-        ];
-        features = {
-          "default" = [ "std" ];
-        };
-        resolvedDefaultFeatures = [ "default" "std" ];
-      };
     "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "failure";
@@ -957,25 +758,6 @@ rec {
           "serialize" = [ "serde" ];
         };
       };
-    "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "indicatif";
-        version = "0.11.0";
-        edition = "2015";
-        sha256 = "11559k3l50s92r84xj260qvrrscmngyk3x68hbivic8bar7g7fhz";
-        authors = [
-          "Armin Ronacher <armin.ronacher@active-4.com>"
-        ];
-        dependencies = {
-          "console" = "console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)";
-          "lazy_static" = "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "number_prefix" = "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)";
-          "parking_lot" = "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "regex" = "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-        };
-      };
     "indoc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "indoc";
@@ -1167,24 +949,6 @@ rec {
           "vcpkg" = {
             packageId = "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)";
             target = (target."env" == "msvc");
-          };
-        };
-        features = {
-        };
-      };
-    "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "lock_api";
-        version = "0.3.1";
-        edition = "2018";
-        sha256 = "0fnav5aq42dcw3z2v9lp8pfrgmf4nnyr3h9i7v5qj9xdzxkp6lry";
-        authors = [
-          "Amanieu d'Antras <amanieu@gmail.com>"
-        ];
-        dependencies = {
-          "scopeguard" = {
-            packageId = "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)";
-            usesDefaultFeatures = false;
           };
         };
         features = {
@@ -1460,21 +1224,6 @@ rec {
         features = {
         };
       };
-    "number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "number_prefix";
-        version = "0.2.8";
-        edition = "2015";
-        sha256 = "0qlm6kx5ynjlqjmc88nb8dlansanxr8ajh1b5sb398d0n59lcikf";
-        authors = [
-          "ogham@bsago.me"
-        ];
-        dependencies = {
-          "num-traits" = "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-        };
-      };
     "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "openssl-probe";
@@ -1529,17 +1278,12 @@ rec {
             packageId = "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)";
             usesDefaultFeatures = false;
           };
-          "serde" = {
-            packageId = "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)";
-            optional = true;
-            usesDefaultFeatures = false;
-          };
         };
         features = {
           "default" = [ "std" ];
           "std" = [ "num-traits/std" ];
         };
-        resolvedDefaultFeatures = [ "default" "serde" "std" ];
+        resolvedDefaultFeatures = [ "default" "std" ];
       };
     "ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
@@ -1552,67 +1296,6 @@ rec {
         ];
         features = {
           "serde-1" = [ "serde" ];
-        };
-      };
-    "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "parking_lot";
-        version = "0.9.0";
-        edition = "2018";
-        sha256 = "0h28hk9yggik2pdyp5rbq31klkms0f34mg3yj6rsd9639jf8hf69";
-        authors = [
-          "Amanieu d'Antras <amanieu@gmail.com>"
-        ];
-        dependencies = {
-          "lock_api" = "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)";
-          "parking_lot_core" = "parking_lot_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        buildDependencies = {
-          "rustc_version" = "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-          "deadlock_detection" = [ "parking_lot_core/deadlock_detection" ];
-          "nightly" = [ "parking_lot_core/nightly" "lock_api/nightly" ];
-          "owning_ref" = [ "lock_api/owning_ref" ];
-          "serde" = [ "lock_api/serde" ];
-        };
-        resolvedDefaultFeatures = [ "default" ];
-      };
-    "parking_lot_core 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "parking_lot_core";
-        version = "0.6.1";
-        edition = "2018";
-        sha256 = "015qc6nnjcv4rvyfiyy7x1ayaacnvxmcyd12vyjmzcbdl8rns4hx";
-        authors = [
-          "Amanieu d'Antras <amanieu@gmail.com>"
-        ];
-        dependencies = {
-          "cfg-if" = "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)";
-          "cloudabi" = {
-            packageId = "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = (target."os" == "cloudabi");
-          };
-          "libc" = {
-            packageId = "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = target."unix";
-          };
-          "redox_syscall" = {
-            packageId = "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = (target."os" == "redox");
-          };
-          "smallvec" = "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)";
-          "winapi" = {
-            packageId = "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)";
-            target = target."windows";
-            features = [ "winnt" "ntstatus" "minwindef" "winerror" "winbase" "errhandlingapi" "handleapi" ];
-          };
-        };
-        buildDependencies = {
-          "rustc_version" = "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-          "deadlock_detection" = [ "petgraph" "thread-id" "backtrace" ];
         };
       };
     "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -2203,21 +1886,6 @@ rec {
           "rustc-dep-of-std" = [ "core" "compiler_builtins" ];
         };
       };
-    "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "rustc_version";
-        version = "0.2.3";
-        edition = "2015";
-        sha256 = "0rgwzbgs3i9fqjm1p4ra3n7frafmpwl29c8lw85kv1rxn7n2zaa7";
-        authors = [
-          "Marvin Löbel <loebel.marvin@gmail.com>"
-        ];
-        dependencies = {
-          "semver" = "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-        };
-      };
     "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "ryu";
@@ -2256,19 +1924,6 @@ rec {
         version = "0.3.3";
         edition = "2015";
         sha256 = "0i1l013csrqzfz6c68pr5pi01hg5v5yahq8fsdmaxy6p8ygsjf3r";
-        authors = [
-          "bluss"
-        ];
-        features = {
-          "default" = [ "use_std" ];
-        };
-      };
-    "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "scopeguard";
-        version = "1.0.0";
-        edition = "2015";
-        sha256 = "15vrix0jx3i4naqnjswddzn4m036krrv71a8vkh3b1zq4hxmrb0q";
         authors = [
           "bluss"
         ];
@@ -2398,21 +2053,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "default" ];
       };
-    "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "smallvec";
-        version = "0.6.10";
-        edition = "2015";
-        sha256 = "01w7xd79q0bwn683gk4ryw50ad1zzxkny10f7gkbaaj1ax6f4q4h";
-        libPath = "lib.rs";
-        authors = [
-          "Simon Sapin <simon.sapin@exyr.org>"
-        ];
-        features = {
-          "default" = [ "std" ];
-        };
-        resolvedDefaultFeatures = [ "default" "std" ];
-      };
     "socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "socket2";
@@ -2457,24 +2097,12 @@ rec {
         features = {
         };
       };
-    "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "stdinout";
-        version = "0.4.0";
-        edition = "2015";
-        sha256 = "197vgpiml8img4n1dgpa4gx7qi8kf87y3gbhlndqp72rifhk7jdd";
-        authors = [
-          "Daniël de Kok <me@danieldk.eu>"
-        ];
-        features = {
-        };
-      };
-    "sticker 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)"
+    "sticker 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "sticker";
-        version = "0.9.0";
+        version = "0.10.0";
         edition = "2018";
-        sha256 = "0v8315jb65iyjal72q5wjyjb1a57gy283n65b23151ja0w264ch0";
+        sha256 = "1si3y84g27jz3ghyfl8rxkpyfxr7z2875568k5v7lqz4ychpwfax";
         authors = [
           "Daniël de Kok <me@danieldk.eu>"
         ];
@@ -2489,9 +2117,11 @@ rec {
           "petgraph" = "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)";
           "protobuf" = "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)";
           "serde" = "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)";
+          "serde_cbor" = "serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)";
           "serde_derive" = "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)";
-          "sticker-tf-proto" = "sticker-tf-proto 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          "sticker-tf-proto" = "sticker-tf-proto 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)";
           "tensorflow" = "tensorflow 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          "toml" = "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)";
         };
         features = {
         };
@@ -2511,17 +2141,17 @@ rec {
             packageId = "pyo3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)";
             features = [ "extension-module" ];
           };
-          "sticker-utils" = "sticker-utils 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)";
+          "sticker" = "sticker 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)";
         };
         features = {
         };
       };
-    "sticker-tf-proto 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)"
+    "sticker-tf-proto 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "sticker-tf-proto";
-        version = "0.7.0";
+        version = "0.10.0";
         edition = "2018";
-        sha256 = "0vyz4dnnkcq3xgqa569ssjbqr3svap0sx7ry4ralc9w43ixlvlk1";
+        sha256 = "1b418z2m2zx4lyxxbic6f3qiflymbz1kqmgz17pa0k1k0wyadiwz";
         authors = [
           "Daniël de Kok <me@danieldk.eu>"
         ];
@@ -2530,51 +2160,6 @@ rec {
         };
         features = {
           "proto-compile" = [ "protoc-rust" ];
-        };
-      };
-    "sticker-utils 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "sticker-utils";
-        version = "0.9.0";
-        edition = "2018";
-        # Hack to suppress building binaries
-        crateBin = [{name = ","; path = ",";}];
-        sha256 = "1ms431a04lldi113s67n24af8f57yi4cqcm3f1rv030k9qyw8s1s";
-        authors = [
-          "Daniël de Kok <me@danieldk.eu>"
-        ];
-        dependencies = {
-          "clap" = "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "conllx" = "conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)";
-          "failure" = "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)";
-          "finalfusion" = "finalfusion 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)";
-          "indicatif" = "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "ordered-float" = {
-            packageId = "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)";
-            features = [ "serde" ];
-          };
-          "serde" = "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)";
-          "serde_cbor" = "serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)";
-          "serde_derive" = "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)";
-          "stdinout" = "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "sticker" = "sticker 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "tensorflow" = "tensorflow 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)";
-          "threadpool" = "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)";
-          "toml" = "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-        };
-      };
-    "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "strsim";
-        version = "0.8.0";
-        edition = "2015";
-        sha256 = "0d3jsdz22wgjyxdakqnvdgmwjdvkximz50d9zfk4qlalw635qcvy";
-        authors = [
-          "Danny Guo <dannyguo91@gmail.com>"
-        ];
-        features = {
         };
       };
     "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -2732,36 +2317,6 @@ rec {
         features = {
         };
       };
-    "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "termios";
-        version = "0.3.1";
-        edition = "2015";
-        sha256 = "1h0fwglrhay85fkbl05ym5gh8hxzl7pyz0a51zfmmngxrf7823c2";
-        authors = [
-          "David Cuddeback <david.cuddeback@gmail.com>"
-        ];
-        dependencies = {
-          "libc" = "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-        };
-      };
-    "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "textwrap";
-        version = "0.11.0";
-        edition = "2015";
-        sha256 = "0s25qh49n7kjayrdj4q3v0jk0jc6vy88rdw0bvgfxqlscpqpxi7d";
-        authors = [
-          "Martin Geisler <martin@geisler.net>"
-        ];
-        dependencies = {
-          "unicode-width" = "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-        };
-      };
     "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
         crateName = "thread_local";
@@ -2773,23 +2328,6 @@ rec {
         ];
         dependencies = {
           "lazy_static" = "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)";
-        };
-        features = {
-        };
-      };
-    "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "threadpool";
-        version = "1.7.1";
-        edition = "2015";
-        sha256 = "09g715plrn59kasvigqjrjqzcgqnaf6v6pia0xx03f18kvfmkq06";
-        authors = [
-          "The Rust Project Developers"
-          "Corey Farwell <coreyf@rwell.org>"
-          "Stefan Schindler <dns2utf8@estada.ch>"
-        ];
-        dependencies = {
-          "num_cpus" = "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)";
         };
         features = {
         };
@@ -2808,19 +2346,6 @@ rec {
         };
         features = {
           "preserve_order" = [ "linked-hash-map" ];
-        };
-        resolvedDefaultFeatures = [ "default" ];
-      };
-    "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "unicode-width";
-        version = "0.1.5";
-        edition = "2015";
-        sha256 = "0886lc2aymwgy0lhavwn6s48ik3c61ykzzd3za6prgnw51j7bi4w";
-        authors = [
-          "kwantam <kwantam@gmail.com>"
-        ];
-        features = {
         };
         resolvedDefaultFeatures = [ "default" ];
       };
@@ -2874,44 +2399,6 @@ rec {
           "Jim McGrath <jimmc2@gmail.com>"
         ];
         features = {
-        };
-      };
-    "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)"
-      = rec {
-        crateName = "vec_map";
-        version = "0.8.1";
-        edition = "2015";
-        sha256 = "1jj2nrg8h3l53d43rwkpkikq5a5x15ms4rf1rw92hp5lrqhi8mpi";
-        authors = [
-          "Alex Crichton <alex@alexcrichton.com>"
-          "Jorge Aparicio <japaricious@gmail.com>"
-          "Alexis Beingessner <a.beingessner@gmail.com>"
-          "Brian Anderson <>"
-          "tbu- <>"
-          "Manish Goregaokar <>"
-          "Aaron Turon <aturon@mozilla.com>"
-          "Adolfo Ochagavía <>"
-          "Niko Matsakis <>"
-          "Steven Fackler <>"
-          "Chase Southwood <csouth3@illinois.edu>"
-          "Eduard Burtescu <>"
-          "Florian Wilkens <>"
-          "Félix Raimundo <>"
-          "Tibor Benke <>"
-          "Markus Siemens <markus@m-siemens.de>"
-          "Josh Branchaud <jbranchaud@gmail.com>"
-          "Huon Wilson <dbau.pp@gmail.com>"
-          "Corey Farwell <coref@rwell.org>"
-          "Aaron Liblong <>"
-          "Nick Cameron <nrc@ncameron.org>"
-          "Patrick Walton <pcwalton@mimiga.net>"
-          "Felix S Klock II <>"
-          "Andrew Paseltiner <apaseltiner@gmail.com>"
-          "Sean McArthur <sean.monstar@gmail.com>"
-          "Vadim Petrochenkov <>"
-        ];
-        features = {
-          "eders" = [ "serde" ];
         };
       };
     "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)"
@@ -2975,7 +2462,7 @@ rec {
         features = {
           "debug" = [ "impl-debug" ];
         };
-        resolvedDefaultFeatures = [ "basetsd" "consoleapi" "errhandlingapi" "fileapi" "handleapi" "lmcons" "memoryapi" "minschannel" "minwinbase" "minwindef" "ntstatus" "processenv" "schannel" "securitybaseapi" "sspi" "std" "sysinfoapi" "timezoneapi" "winbase" "wincon" "wincrypt" "winerror" "winnt" "winsock2" "winuser" "ws2def" "ws2ipdef" "ws2tcpip" ];
+        resolvedDefaultFeatures = [ "basetsd" "fileapi" "handleapi" "lmcons" "memoryapi" "minschannel" "minwindef" "schannel" "securitybaseapi" "sspi" "std" "sysinfoapi" "timezoneapi" "winbase" "wincrypt" "winerror" "winsock2" "ws2def" "ws2ipdef" "ws2tcpip" ];
       };
     "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {
@@ -3093,11 +2580,20 @@ rec {
       builtins.match "^\\.sw[a-z]$$" baseName != null ||
       builtins.match "^\\..*\\.sw[a-z]$$" baseName != null ||
       lib.hasSuffix ".tmp" baseName ||
-      lib.hasSuffix ".bak" baseName
+      lib.hasSuffix ".bak" baseName ||
+      baseName == "tests.nix"
     );
 
+  /* A restricted overridable version of  buildRustCrateWithFeaturesImpl. */
+  buildRustCrateWithFeatures = {packageId, features}:
+    lib.makeOverridable
+      (args@{features, ...}:
+        let buildRustCrateArgs = lib.filterAttrs (n: _: n != "features") args;
+        in (buildRustCrateWithFeaturesImpl {inherit packageId features;}).override buildRustCrateArgs)
+      { inherit features; };
+
   /* Returns a buildRustCrate derivation for the given packageId and features. */
-  buildRustCrateWithFeatures = { crateConfigs? crates, packageId, features } @ args:
+  buildRustCrateWithFeaturesImpl = { crateConfigs? crates, packageId, features } @ args:
     assert (builtins.isAttrs crateConfigs);
     assert (builtins.isString packageId);
     assert (builtins.isList features);

--- a/nix/sticker.nix
+++ b/nix/sticker.nix
@@ -3,6 +3,6 @@
 callPackage (fetchFromGitHub {
   owner = "stickeritis";
   repo = "nix-packages";
-  rev = "d88a501";
-  sha256 = "1qcp7z1hl1qh0dkf1iwh88a2ahwqakfzkqcpzm1lhy4m54p155xc";
+  rev = "9ca1cfb";
+  sha256 = "1292bamr002spby7w0l6k2fx965qg0lzg7n2ny6nzw32k13gq3wq";
 }) {}

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use pyo3::class::basic::PyObjectProtocol;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 
-use sticker_utils::{Config, TomlRead};
+use sticker::wrapper::{Config, TomlRead};
 
 /// Config(file)
 /// --

--- a/src/tagger.rs
+++ b/src/tagger.rs
@@ -1,7 +1,7 @@
 use pyo3::exceptions;
 use pyo3::prelude::*;
 
-use sticker_utils::{Pipeline, TaggerWrapper};
+use sticker::wrapper::{Pipeline, Tagger};
 
 use crate::PyConfig;
 use crate::PySentence;
@@ -20,7 +20,7 @@ impl PyPipeline {
             .iter()
             .map(|config| config.as_ref().clone())
             .collect::<Vec<_>>();
-        let pipeline = Pipeline::new_from_configs(configs.as_slice())
+        let pipeline = Pipeline::from_configs(configs.as_slice())
             .map_err(|err| exceptions::IOError::py_err(err.to_string()))?;
 
         obj.init(PyPipeline { inner: pipeline });
@@ -77,14 +77,14 @@ impl PyPipeline {
 /// from a configuration.
 #[pyclass(name=Tagger)]
 pub struct PyTagger {
-    inner: TaggerWrapper,
+    inner: Tagger,
 }
 
 #[pymethods]
 impl PyTagger {
     #[new]
     fn __new__(obj: &PyRawObject, config: &PyConfig) -> PyResult<()> {
-        let tagger = TaggerWrapper::new(&*config.as_ref())
+        let tagger = Tagger::new(&*config.as_ref())
             .map_err(|err| exceptions::IOError::py_err(err.to_string()))?;
 
         obj.init(PyTagger { inner: tagger });


### PR DESCRIPTION
In this release, the necessary data structures have moved from the
sticker-utils crate to the sticker crate. So, sticker-python now uses
the sticker crate as a dependency. This also removes some command
line-based transitive dependencies.